### PR TITLE
fix: move pitest and javadoc to new directories

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -43,9 +43,9 @@ jobs:
       - name: Build javadoc Step
         run: ./gradlew javadoc
       - name: Move Pitest step
-        run: mv ./build/reports/pitest ./web/gh-pages
+        run: mv ./build/reports/pitest ./docs/gh-pages/pit
       - name: Move javadoc step
-        run: mv ./build/docs/javadoc ./docs/gh-pages
+        run: mv ./build/docs/javadoc ./docs/gh-pages/docs
       - name: Deploy Pitest to GitHub Pages Step
         uses: peaceiris/actions-gh-pages@v4
         # If you're changing the branch from main,


### PR DESCRIPTION
This commit changes the location of pitest and javadoc reports. Pitest reports are now moved to ./docs/gh-pages/pit and javadoc to ./docs/gh-pages/docs.

closes #71 