### PR TITLE
refactor: remove pull_request trigger from semgrep and snyk workflows

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,10 +1,13 @@
 on:
   workflow_dispatch: {}
-  pull_request:
-    branches: ["dev"]
+  # pull_request:
+  #   branches: ["dev"]
+  push:
+    branches:
+      - dev
   schedule:
     - cron: 11 2 * * *
-name: Semgrep
+name: Semgrep Workflow
 jobs:
   semgrep:
     permissions:
@@ -13,7 +16,7 @@ jobs:
       actions: read
       contents: read
     if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
-    name: Semgrep/ci Job
+    name: Semgrep Job
     runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,7 +1,10 @@
 name: Snyk Security Scan Workflow
 on:
-  pull_request:
-    branches: ["dev"]
+  # pull_request:
+  #   branches: ["dev"]
+  push:
+    branches:
+      - dev
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
due to security reasons, we should not run the semgrep and snyk workflows from a forked PR. This is because the secrets are not exposed to the PR and thus the workflows will fail.